### PR TITLE
Add support for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "rossmc/jsonpricefix"
+  , "type": "magento-module"
+  , "license": "Open Software License (OSL 3.0)"
+  , "description": "Rossmc JsonPriceFix for Magento 1.9.3"
+  , "require": {
+      "magento-hackathon/magento-composer-installer": "~3.0"
+    }
+}

--- a/modman
+++ b/modman
@@ -1,0 +1,2 @@
+app/code/community/Rossmc/JsonPriceFix  app/code/community/Rossmc/JsonPriceFix
+app/etc/modules/*                           app/etc/modules/


### PR DESCRIPTION
These two small files will allow Magento users that use Composer to simply point to your github project to include this module.